### PR TITLE
Add turn conversation claim handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/praekeltfoundation/vumi-whatsapp"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-sanic = "~20.12"
+sanic = "^20.12.1"
 sentry-sdk = "^0.19.5"
 prometheus-client = "^0.9.0"
 jsonschema = "^3.2.0"

--- a/vxwhatsapp/consumer.py
+++ b/vxwhatsapp/consumer.py
@@ -29,11 +29,16 @@ class Consumer:
             connector=aiohttp.TCPConnector(limit=config.CONCURRENCY),
             headers={"Authorization": f"Bearer {config.API_TOKEN}"},
         )
-        self.message_url = urlunparse(
+        self.api_host = config.API_HOST
+        self.message_url = self._make_url("/v1/messages")
+        self.message_automation_url = self._make_url("/v1/messages/{}/automation")
+
+    def _make_url(self, path):
+        return urlunparse(
             ParseResult(
                 scheme="https",
-                netloc=config.API_HOST,
-                path="/v1/messages",
+                netloc=self.api_host,
+                path=path,
                 params="",
                 query="",
                 fragment="",
@@ -80,6 +85,7 @@ class Consumer:
         # TODO: support more message types
 
         headers: Dict[str, str] = {}
+        url = self.message_url
         if claim := message.transport_metadata.get("claim"):
             if (
                 message.session_event == Message.SESSION_EVENT.RESUME
@@ -88,9 +94,14 @@ class Consumer:
                 headers["X-Turn-Claim-Extend"] = claim
             elif message.session_event == Message.SESSION_EVENT.CLOSE:
                 headers["X-Turn-Claim-Release"] = claim
+                if (
+                    message.transport_metadata.get("automation_handle")
+                    and message.in_reply_to
+                ):
+                    url = self.message_automation_url.format(message.in_reply_to)
 
         await self.session.post(
-            self.message_url,
+            url,
             headers=headers,
             json={"to": message.to_addr, "text": {"body": message.content or ""}},
         )

--- a/vxwhatsapp/tests/test_consumer.py
+++ b/vxwhatsapp/tests/test_consumer.py
@@ -20,6 +20,7 @@ def test_client(loop, sanic_client):
 
 @pytest.fixture
 def whatsapp_mock_server(loop, sanic_client):
+    Sanic.test_mode = True
     app = Sanic("mock_whatsapp")
     app.future = Future()
 
@@ -53,7 +54,7 @@ async def send_outbound_message(connection: Connection, message: Message):
 
 async def test_outbound_text_message(whatsapp_mock_server, test_client):
     """
-    Should make a request to the whatsapp API
+    Should make a request to the whatsapp API, extending the conversation claim
     """
     test_client.app.consumer.message_url = (
         f"http://{whatsapp_mock_server.host}:{whatsapp_mock_server.port}/v1/messages"
@@ -65,11 +66,37 @@ async def test_outbound_text_message(whatsapp_mock_server, test_client):
             from_addr="27820001002",
             transport_name="whatsapp",
             transport_type=Message.TRANSPORT_TYPE.HTTP_API,
+            transport_metadata={"claim": "test-claim"},
             content="test message",
         ),
     )
     request = await whatsapp_mock_server.app.future
     assert request.json == {"text": {"body": "test message"}, "to": "27820001001"}
+    assert request.headers["X-Turn-Claim-Extend"] == "test-claim"
+
+
+async def test_outbound_text_end_session(whatsapp_mock_server, test_client):
+    """
+    Should make a request to the whatsapp API, releasing the conversation claim
+    """
+    test_client.app.consumer.message_url = (
+        f"http://{whatsapp_mock_server.host}:{whatsapp_mock_server.port}/v1/messages"
+    )
+    await send_outbound_message(
+        test_client.app.amqp_connection,
+        Message(
+            to_addr="27820001001",
+            from_addr="27820001002",
+            transport_name="whatsapp",
+            transport_type=Message.TRANSPORT_TYPE.HTTP_API,
+            transport_metadata={"claim": "test-claim"},
+            content="test message",
+            session_event=Message.SESSION_EVENT.CLOSE,
+        ),
+    )
+    request = await whatsapp_mock_server.app.future
+    assert request.json == {"text": {"body": "test message"}, "to": "27820001001"}
+    assert request.headers["X-Turn-Claim-Release"] == "test-claim"
 
 
 async def test_invalid_outbound_text_message(test_client):

--- a/vxwhatsapp/tests/test_consumer.py
+++ b/vxwhatsapp/tests/test_consumer.py
@@ -29,6 +29,11 @@ def whatsapp_mock_server(loop, sanic_client):
         app.future.set_result(request)
         return json({})
 
+    @app.route("/v1/messages/<message_id>/automation", methods=["POST"])
+    async def message_automation(request, message_id):
+        app.future.set_result(request)
+        return json({})
+
     return loop.run_until_complete(sanic_client(app))
 
 
@@ -97,6 +102,33 @@ async def test_outbound_text_end_session(whatsapp_mock_server, test_client):
     request = await whatsapp_mock_server.app.future
     assert request.json == {"text": {"body": "test message"}, "to": "27820001001"}
     assert request.headers["X-Turn-Claim-Release"] == "test-claim"
+
+
+async def test_outbound_text_automation_handle(whatsapp_mock_server, test_client):
+    """
+    Should make a request to the turn automation API to reevaluate
+    """
+    test_client.app.consumer.message_automation_url = (
+        f"http://{whatsapp_mock_server.host}:{whatsapp_mock_server.port}"
+        "/v1/messages/{}/automation"
+    )
+    await send_outbound_message(
+        test_client.app.amqp_connection,
+        Message(
+            to_addr="27820001001",
+            from_addr="27820001002",
+            transport_name="whatsapp",
+            transport_type=Message.TRANSPORT_TYPE.HTTP_API,
+            transport_metadata={"claim": "test-claim", "automation_handle": True},
+            content="test message",
+            session_event=Message.SESSION_EVENT.CLOSE,
+            in_reply_to="message-id",
+        ),
+    )
+    request = await whatsapp_mock_server.app.future
+    assert request.json == {"text": {"body": "test message"}, "to": "27820001001"}
+    assert request.headers["X-Turn-Claim-Release"] == "test-claim"
+    assert "/v1/messages/message-id/automation" in request.url
 
 
 async def test_invalid_outbound_text_message(test_client):

--- a/vxwhatsapp/tests/test_whatsapp.py
+++ b/vxwhatsapp/tests/test_whatsapp.py
@@ -65,7 +65,7 @@ async def test_valid_signature(test_client):
 
 async def setup_amqp_queue(connection: Connection, queuename="whatsapp.inbound"):
     channel = await connection.channel()
-    queue = await channel.declare_queue(queuename, auto_delete=True, passive=True)
+    queue = await channel.declare_queue(queuename, auto_delete=True)
     await queue.bind("vumi", queuename)
     return queue
 

--- a/vxwhatsapp/tests/test_whatsapp.py
+++ b/vxwhatsapp/tests/test_whatsapp.py
@@ -65,7 +65,7 @@ async def test_valid_signature(test_client):
 
 async def setup_amqp_queue(connection: Connection, queuename="whatsapp.inbound"):
     channel = await connection.channel()
-    queue = await channel.declare_queue(queuename, auto_delete=True)
+    queue = await channel.declare_queue(queuename, auto_delete=True, passive=True)
     await queue.bind("vumi", queuename)
     return queue
 
@@ -95,7 +95,10 @@ async def test_valid_text_message(test_client):
     )
     response = await test_client.post(
         app.url_for("whatsapp.whatsapp_webhook"),
-        headers={"X-Turn-Hook-Signature": generate_hmac_signature(data, "testsecret")},
+        headers={
+            "X-Turn-Hook-Signature": generate_hmac_signature(data, "testsecret"),
+            "X-Turn-Claim": "test-claim",
+        },
         data=data,
     )
     assert response.status == 200
@@ -107,7 +110,11 @@ async def test_valid_text_message(test_client):
     assert message.content == "test message"
     assert message.message_id == "abc123"
     assert message.timestamp == datetime(1973, 11, 29, 21, 33, 9, tzinfo=timezone.utc)
-    assert message.transport_metadata == {"contacts": None, "message": {"type": "text"}}
+    assert message.transport_metadata == {
+        "contacts": None,
+        "message": {"type": "text"},
+        "claim": "test-claim",
+    }
 
 
 async def test_ignore_system_messages(test_client):

--- a/vxwhatsapp/whatsapp.py
+++ b/vxwhatsapp/whatsapp.py
@@ -49,6 +49,7 @@ async def whatsapp_webhook(request: Request) -> HTTPResponse:
             transport_metadata={
                 "contacts": request.json.get("contacts"),
                 "message": msg,
+                "claim": request.headers.get("X-Turn-Claim"),
             },
         )
         tasks.append(request.app.publisher.publish_message(message))


### PR DESCRIPTION
This allows us to extend the turn conversation if present, release it if we want the session to end, and submit it back to turn automation for special cases

Relevant docs: https://whatsapp.turn.io/docs/index.html#conversation-claiming