### PR TITLE
Fix schema for button messages

### DIFF
--- a/vxwhatsapp/schema.py
+++ b/vxwhatsapp/schema.py
@@ -69,7 +69,7 @@ whatsapp_webhook_schema = {
                 "button": {
                     "type": "object",
                     "properties": {
-                        "payload": {"type": "string"},
+                        "payload": {"type": ["string", "null"]},
                         "text": {"type": "string"},
                     },
                 },

--- a/vxwhatsapp/tests/test_schema.py
+++ b/vxwhatsapp/tests/test_schema.py
@@ -153,7 +153,7 @@ whatsapp_valid = [
         "contacts": [{"profile": {"name": "Kerry Fisher"}, "wa_id": "16505551234"}],
         "messages": [
             {
-                "button": {"payload": "No-Button-Payload", "text": "No"},
+                "button": {"payload": None, "text": "No"},
                 "context": {"from": "16315558007", "id": "gBGGFmkiWVVPAgkgQkwi7IORac0"},
                 "from": "16505551234",
                 "id": "ABGGFmkiWVVPAgo-sKD87hgxPHdF",


### PR DESCRIPTION
There's no documentation for button messages, so while the example shows the payload to be a string, if you don't supply the payload then the key isn't missing, it gets set to null