### PR TITLE
Allow null captions

### DIFF
--- a/vxwhatsapp/consumer.py
+++ b/vxwhatsapp/consumer.py
@@ -146,7 +146,7 @@ class Consumer:
                     headers["Accept"] = "application/vnd.v1+json"
                 await delete_conversation_claim(self.redis, claim, message.to_addr)
 
-        data: dict[str, Any] = {"to": message.to_addr}
+        data: Dict[str, Any] = {"to": message.to_addr}
 
         if "buttons" in message.helper_metadata:
             options = message.helper_metadata["buttons"]

--- a/vxwhatsapp/schema.py
+++ b/vxwhatsapp/schema.py
@@ -10,7 +10,7 @@ whatsapp_webhook_schema = {
         "media": {
             "type": "object",
             "properties": {
-                "caption": {"type": "string"},
+                "caption": {"type": ["string", "null"]},
                 "id": {"type": "string"},
                 "metadata": {"type": "object"},
                 "mime_type": {"type": "string"},

--- a/vxwhatsapp/tests/test_claims.py
+++ b/vxwhatsapp/tests/test_claims.py
@@ -5,6 +5,7 @@ from aioredis import Redis, from_url
 
 from vxwhatsapp import config
 from vxwhatsapp.claims import delete_conversation_claim, store_conversation_claim
+from vxwhatsapp.tests.utils import cleanup_redis
 
 
 @pytest.fixture
@@ -14,6 +15,7 @@ async def redis() -> AsyncGenerator[Redis, None]:
     )
     yield conn
     await conn.close()
+    await cleanup_redis()
 
 
 async def test_store_missing_parameters(redis):

--- a/vxwhatsapp/tests/test_consumer.py
+++ b/vxwhatsapp/tests/test_consumer.py
@@ -13,6 +13,16 @@ from sanic.response import json, text
 from vxwhatsapp import config
 from vxwhatsapp.main import app
 from vxwhatsapp.models import Message
+from vxwhatsapp.tests.utils import cleanup_amqp, cleanup_redis
+
+
+@pytest.fixture(autouse=True)
+async def cleanup():
+    """
+    Ensure that we always cleanup redis and amqp
+    """
+    await cleanup_amqp()
+    await cleanup_redis()
 
 
 @pytest.fixture

--- a/vxwhatsapp/tests/test_main.py
+++ b/vxwhatsapp/tests/test_main.py
@@ -2,6 +2,16 @@ import pytest
 
 from vxwhatsapp import config
 from vxwhatsapp.main import app
+from vxwhatsapp.tests.utils import cleanup_amqp, cleanup_redis
+
+
+@pytest.fixture(autouse=True)
+async def cleanup():
+    """
+    Ensure that we always cleanup redis and amqp
+    """
+    await cleanup_amqp()
+    await cleanup_redis()
 
 
 @pytest.fixture

--- a/vxwhatsapp/tests/test_publisher.py
+++ b/vxwhatsapp/tests/test_publisher.py
@@ -10,6 +10,7 @@ from aioredis import Redis, from_url
 from vxwhatsapp import config
 from vxwhatsapp.models import Message
 from vxwhatsapp.publisher import Publisher
+from vxwhatsapp.tests.utils import cleanup_amqp, cleanup_redis
 
 
 @pytest.fixture
@@ -17,6 +18,7 @@ async def amqp() -> AsyncGenerator[Connection, None]:
     conn: Connection = await connect_robust(config.AMQP_URL)
     yield conn
     await conn.close()
+    await cleanup_amqp()
 
 
 @pytest.fixture
@@ -26,6 +28,7 @@ async def redis() -> AsyncGenerator[Redis, None]:
     )
     yield conn
     await conn.close()
+    await cleanup_redis()
 
 
 async def setup_amqp_queue(amqp: Connection, queuename="whatsapp.inbound") -> Queue:

--- a/vxwhatsapp/tests/test_whatsapp.py
+++ b/vxwhatsapp/tests/test_whatsapp.py
@@ -10,7 +10,17 @@ from aio_pika.exceptions import QueueEmpty
 
 from vxwhatsapp.main import app
 from vxwhatsapp.models import Event, Message
+from vxwhatsapp.tests.utils import cleanup_amqp, cleanup_redis
 from vxwhatsapp.whatsapp import config
+
+
+@pytest.fixture(autouse=True)
+async def cleanup():
+    """
+    Ensure that we always cleanup redis and amqp
+    """
+    await cleanup_amqp()
+    await cleanup_redis()
 
 
 @pytest.fixture

--- a/vxwhatsapp/tests/test_whatsapp.py
+++ b/vxwhatsapp/tests/test_whatsapp.py
@@ -374,6 +374,42 @@ async def test_valid_media_message(test_client):
     assert message.content == "test caption"
 
 
+async def test_valid_media_message_null_caption(test_client):
+    """
+    Should have null message content
+    """
+    queue = await setup_amqp_queue(test_client.app.amqp_connection)
+    data = ujson.dumps(
+        {
+            "messages": [
+                {
+                    "from": "27820001001",
+                    "id": "abc128",
+                    "timestamp": "123456789",
+                    "type": "image",
+                    "image": {
+                        "id": "abc123",
+                        "caption": None,
+                        "mime_type": "image/png",
+                        "sha256": "hash",
+                    },
+                }
+            ]
+        }
+    )
+    response = await test_client.post(
+        app.url_for("whatsapp.whatsapp_webhook"),
+        headers={"X-Turn-Hook-Signature": generate_hmac_signature(data, "testsecret")},
+        data=data,
+    )
+    assert response.status == 200
+    assert (await response.json()) == {}
+
+    message = await get_amqp_message(queue)
+    message = Message.from_json(message.body.decode("utf-8"))
+    assert message.content is None
+
+
 async def test_valid_event(test_client):
     queue = await setup_amqp_queue(test_client.app.amqp_connection, "whatsapp.event")
     data = ujson.dumps(

--- a/vxwhatsapp/tests/utils.py
+++ b/vxwhatsapp/tests/utils.py
@@ -1,0 +1,36 @@
+import aioredis
+from aio_pika import connect_robust
+
+from vxwhatsapp import config
+
+
+async def cleanup_redis():
+    redis = aioredis.from_url(
+        config.REDIS_URL or "redis://", encoding="utf-8", decode_responses=True
+    )
+    await redis.delete("claims")
+    for key in await redis.keys("msglock:*"):
+        await redis.delete(key)
+    for key in await redis.keys("msgseen:*"):
+        await redis.delete(key)
+    await redis.close()
+
+
+async def cleanup_amqp():
+    connection = await connect_robust(config.AMQP_URL)
+    async with connection:
+        channel = await connection.channel()
+        for routing_key in [
+            f"{config.TRANSPORT_NAME}.inbound",
+            f"{config.TRANSPORT_NAME}.outbound",
+            f"{config.TRANSPORT_NAME}.event",
+            f"{config.TRANSPORT_NAME}.answer",
+        ]:
+            queue = await channel.declare_queue(
+                routing_key, durable=True, auto_delete=False
+            )
+            while True:
+                message = await queue.get(fail=False)
+                if message is None:
+                    break
+                message.ack()


### PR DESCRIPTION
There has been a change to the webhooks that we receive. Instead of the caption being missing when there is no media caption, it is now present and has a null value. We need to allow for this.