### PR TITLE
Don't double reject messages

### DIFF
--- a/vxwhatsapp/consumer.py
+++ b/vxwhatsapp/consumer.py
@@ -94,26 +94,26 @@ class Consumer:
             await message.reject(requeue=False)
             return
 
-        async with message.process():
-            logger.debug(f"Processing outbound message {msg}")
-            try:
-                await self.submit_message(msg)
-            except aiohttp.ClientResponseError as e:
-                # If it's a retryable upstream error, requeue the message
-                if e.status > 499:
-                    await message.reject(requeue=True)
-                    # If we've retried this before, wait before retrying again
-                    if message.redelivered:
-                        await sleep(0.5)
-                    return
-
+        logger.debug(f"Processing outbound message {msg}")
+        try:
+            await self.submit_message(msg)
+        except aiohttp.ClientResponseError as e:
+            # If it's a retryable upstream error, requeue the message
+            if e.status > 499:
+                await message.reject(requeue=True)
+                # If we've retried this before, wait before retrying again
+                if message.redelivered:
+                    await sleep(0.5)
+            else:
                 # Otherwise log the error and reject
                 logger.exception(f"Upstream HTTP error processing {msg}")
                 await message.reject(requeue=False)
-            except Exception:
-                # Any other errors aren't recoverable, so log and reject
-                logger.exception(f"Error processing {msg}")
-                await message.reject(requeue=False)
+        except Exception:
+            # Any other errors aren't recoverable, so log and reject
+            logger.exception(f"Error processing {msg}")
+            await message.reject(requeue=False)
+        else:
+            await message.ack()
 
     async def get_media_id(self, media_url):
         if media_url in self.media_cache:


### PR DESCRIPTION
In a `message.process` block, the message will automatically be ack'd or rejected depending on whether an exception is thrown or not.

Since we sometimes want to reject with requeue, and sometimes without, we cannot use this mechanism, so rather handle it manually
