### PR TITLE
Remove requirement for recipient_id for statuses

### DIFF
--- a/vxwhatsapp/schema.py
+++ b/vxwhatsapp/schema.py
@@ -185,6 +185,10 @@ whatsapp_webhook_schema = {
             "properties": {
                 "id": {"type": "string"},
                 "recipient_id": {"type": "string"},
+                "message": {
+                    "type": "object",
+                    "properties": {"recipient_id": {"type": "string"}},
+                },
                 "status": {
                     "type": "string",
                     "enum": ["read", "delivered", "sent", "failed", "deleted"],
@@ -202,7 +206,7 @@ whatsapp_webhook_schema = {
                     },
                 },
             },
-            "required": ["id", "recipient_id", "status", "timestamp"],
+            "required": ["id", "status", "timestamp"],
         },
         "error": {
             "type": "object",


### PR DESCRIPTION
Currently, we require the `recipient_id` field.

WhatsApp are changing the API, so that this field is now located in
`message.recipient_id` in the status instead.

Since we're not actually using this field, we can just remove it from
the list of required fields
