### PR TITLE
added new pricing model field to api

### DIFF
--- a/vxwhatsapp/schema.py
+++ b/vxwhatsapp/schema.py
@@ -201,7 +201,7 @@ whatsapp_webhook_schema = {
                 "pricing": {
                     "type": "object",
                     "properties": {
-                        "pricing_model": {"type": "string", "enum": ["CBP", "NBP"]},
+                        "pricing_model": {"type": "string", "enum": ["CBP", "NBP", "PMP"]},
                         "billable": {"type": "boolean"},
                     },
                 },

--- a/vxwhatsapp/schema.py
+++ b/vxwhatsapp/schema.py
@@ -201,7 +201,7 @@ whatsapp_webhook_schema = {
                 "pricing": {
                     "type": "object",
                     "properties": {
-                        "pricing_model": {"type": "string", "enum": ["CBP", "NBP", "PMP"]},
+                        "pricing_model": {"type": "string", "enum": ["CBP", "PMP"]},
                         "billable": {"type": "boolean"},
                     },
                 },


### PR DESCRIPTION
Meta has released a new pricing model: "PMP" — indicates per-message pricing applies. This exclusion caused errors on the YAL Turn API call, so this fixes that. 